### PR TITLE
#-: FIx module name

### DIFF
--- a/src/page-module/index.ts
+++ b/src/page-module/index.ts
@@ -3,7 +3,10 @@ import {
   getProjectPath,
   getRoutingModulePath,
   parseLocation,
-  isThereDependencyInPackageJson
+  isThereDependencyInPackageJson,
+  camelize,
+  classify,
+  dasherize
 } from '../../core';
 import {
   apply,
@@ -18,7 +21,7 @@ import {
   Tree,
   url
 } from '@angular-devkit/schematics';
-import { join, Path, strings } from '@angular-devkit/core';
+import { join, Path } from '@angular-devkit/core';
 import { Schema as PageModuleOptions } from './schema';
 
 function prepareOptions(host: Tree, options: PageModuleOptions): void {
@@ -102,7 +105,9 @@ function getPageTemplateSource(host: Tree, options: PageModuleOptions): Source {
   return apply(url('./files'), [
     template({
       ...options,
-      ...strings,
+      camelize,
+      classify,
+      dasherize,
       hasParent: !!options.parent,
       isJestInstalled,
       isNgxTranslateInstalled,


### PR DESCRIPTION
There is a bug relates to incorrect component and module names. The reason - usage of native `classify` function instead of our custom. I checked how facade was created after last changes but forgot to check all other files. Lint was also OK.

<img width="332" alt="Снимок экрана 2020-12-09 в 05 20 31" src="https://user-images.githubusercontent.com/1735581/101553261-7eee4700-39de-11eb-8c2b-40f1a31750f7.png">
